### PR TITLE
add additionalProperties (map fields) support

### DIFF
--- a/src/docs/generated/examples.md
+++ b/src/docs/generated/examples.md
@@ -89,6 +89,10 @@
 
 <img src="../../../src/docs/tests/one-of-property-level-required.puml.svg"/>
 
+* [additional-properties-complex.yml](../../../src/test/resources/inputs/additional-properties-complex.yml)
+
+<img src="../../../src/docs/tests/additional-properties-complex.puml.svg"/>
+
 * [all-of-class-level.yml](../../../src/test/resources/inputs/all-of-class-level.yml)
 
 <img src="../../../src/docs/tests/all-of-class-level.puml.svg"/>

--- a/src/docs/generated/examples.md
+++ b/src/docs/generated/examples.md
@@ -105,6 +105,10 @@
 
 <img src="../../../src/docs/tests/parameter-ref-complex.puml.svg"/>
 
+* [additional-properties-simple.yml](../../../src/test/resources/inputs/additional-properties-simple.yml)
+
+<img src="../../../src/docs/tests/additional-properties-simple.puml.svg"/>
+
 * [empty.yml](../../../src/test/resources/inputs/empty.yml)
 
 <img src="../../../src/docs/tests/empty.puml.svg"/>

--- a/src/main/java/com/github/davidmoten/oas3/internal/Common.java
+++ b/src/main/java/com/github/davidmoten/oas3/internal/Common.java
@@ -115,7 +115,7 @@ final class Common {
                     String ref = sch.get$ref();
                     String otherClassName = names.refToClassName(ref).className();
                     addToOne(relationships, name, otherClassName, property,
-                            required.contains(entry.getKey()));
+                            required.contains(entry.getKey()), false);
                 } else {
                     Optional<String> t = getUmlTypeName(sch, names);
                     if (t.isPresent()) {
@@ -130,7 +130,7 @@ final class Common {
                             classes.addAll(m.classes());
                             relationships.addAll(m.relationships());
                             addToOne(relationships, name, otherClassName, property,
-                                    required.contains(property));
+                                    required.contains(property), true);
                         } else if (type.equals("map")) {
                             MapSchema ms = (MapSchema) sch;
                             Schema<?> valueSchema = ((Schema<?>) ms.getAdditionalProperties());
@@ -144,7 +144,7 @@ final class Common {
                                 relationships.addAll(m.relationships());
                                 addToMany(relationships, name, keyClassName, property, true);
                                 String valueClassName = names.refToClassName(valueSchema.get$ref()).className();
-                                addToOne(relationships, keyClassName, valueClassName, "value", true);
+                                addToOne(relationships, keyClassName, valueClassName, "value", true, false);
                             } else {
                                 fields.add(new Field(entry.getKey(), "string -> string", type.endsWith("]"),
                                         true));
@@ -228,7 +228,7 @@ final class Common {
         List<String> otherClassNames = addAnonymousClassesAndReturnOtherClassNames(classes,
                 relationships, name, schemas, names, propertyName);
         for (String otherClassName : otherClassNames) {
-            addToOne(relationships, name, otherClassName, propertyName, true);
+            addToOne(relationships, name, otherClassName, propertyName, true, false);
         }
     }
 
@@ -286,9 +286,8 @@ final class Common {
                 .propertyOrParameterName(Optional.ofNullable(property)).owns(owns).build());
     }
 
-
     private static void addToOne(List<Relationship> relationships, String name,
-            String otherClassName, String property, boolean isToOne) {
+            String otherClassName, String property, boolean isToOne, boolean owns) {
         relationships.add(Association //
                 .from(name) //
                 .to(otherClassName) //
@@ -296,6 +295,7 @@ final class Common {
                 .propertyOrParameterName(//
                         property == null || property.equals(otherClassName) ? Optional.empty()
                                 : Optional.of(property))
+                .owns(owns) //
                 .build());
     }
 

--- a/src/main/java/com/github/davidmoten/oas3/internal/Common.java
+++ b/src/main/java/com/github/davidmoten/oas3/internal/Common.java
@@ -279,11 +279,11 @@ final class Common {
             String otherClassName, String property) {
         addToMany(relationships, name, otherClassName, property, false);
     }
-    
+
     private static void addToMany(List<Relationship> relationships, String name, String otherClassName, String property,
             boolean owns) {
         relationships.add(Association.from(name).to(otherClassName).many()
-                .propertyOrParameterName(Optional.ofNullable(property)).owns(owns).build());        
+                .propertyOrParameterName(Optional.ofNullable(property)).owns(owns).build());
     }
 
 

--- a/src/main/java/com/github/davidmoten/oas3/internal/Common.java
+++ b/src/main/java/com/github/davidmoten/oas3/internal/Common.java
@@ -340,7 +340,6 @@ final class Common {
         } else if (schema instanceof UUIDSchema) {
             type = "string";
         } else if (schema instanceof MapSchema) {
-            // TODO handle MapSchema
             type = "map";
         } else if (schema instanceof ComposedSchema) {
             // TODO handle ComposedSchema

--- a/src/main/java/com/github/davidmoten/oas3/internal/Common.java
+++ b/src/main/java/com/github/davidmoten/oas3/internal/Common.java
@@ -132,7 +132,9 @@ final class Common {
                             addToOne(relationships, name, otherClassName, property,
                                     required.contains(property));
                         } else if (type.equals("map")) {
-                            fields.add(new Field(entry.getKey(), type, type.endsWith("]"),
+                            MapSchema ms = (MapSchema) sch;
+                            String valueType = ((Schema<?>) ms.getAdditionalProperties()).getType();
+                            fields.add(new Field(entry.getKey(), "string -> " + valueType, type.endsWith("]"),
                                     true));
                         } else {
                             fields.add(new Field(entry.getKey(), type, type.endsWith("]"),

--- a/src/main/java/com/github/davidmoten/oas3/internal/Common.java
+++ b/src/main/java/com/github/davidmoten/oas3/internal/Common.java
@@ -131,6 +131,9 @@ final class Common {
                             relationships.addAll(m.relationships());
                             addToOne(relationships, name, otherClassName, property,
                                     required.contains(property));
+                        } else if (type.equals("map")) {
+                            fields.add(new Field(entry.getKey(), type, type.endsWith("]"),
+                                    true));
                         } else {
                             fields.add(new Field(entry.getKey(), type, type.endsWith("]"),
                                     required.contains(entry.getKey())));

--- a/src/main/java/com/github/davidmoten/oas3/internal/model/Association.java
+++ b/src/main/java/com/github/davidmoten/oas3/internal/model/Association.java
@@ -45,7 +45,7 @@ public final class Association implements Relationship {
     public Optional<String> propertyOrParameterName() {
         return propertyOrParameterName;
     }
-    
+
     public boolean owns() {
         return owns;
     }
@@ -121,7 +121,6 @@ public final class Association implements Relationship {
             b.type = type;
             return new Builder3(b);
         }
-        
     }
 
     public static final class Builder3 {
@@ -155,11 +154,11 @@ public final class Association implements Relationship {
             b.propertyOrParameterName = propertyOrParameterName;
             return this;
         }
-        
+
         public Builder3 owns() {
             return owns(true);
         }
-        
+
         public Builder3 owns(boolean owns) {
             b.owns = owns;
             return this;

--- a/src/main/java/com/github/davidmoten/oas3/internal/model/Association.java
+++ b/src/main/java/com/github/davidmoten/oas3/internal/model/Association.java
@@ -9,15 +9,17 @@ public final class Association implements Relationship {
     private final Optional<String> responseCode;
     private final Optional<String> responseContentType;
     private final Optional<String> propertyOrParameterName;
+    private final boolean owns;
 
     private Association(String from, String to, AssociationType type, Optional<String> responseCode,
-            Optional<String> responseContentType, Optional<String> propertyOrParameterName) {
+            Optional<String> responseContentType, Optional<String> propertyOrParameterName, boolean owns) {
         this.from = from;
         this.to = to;
         this.type = type;
         this.responseCode = responseCode;
         this.responseContentType = responseContentType;
         this.propertyOrParameterName = propertyOrParameterName;
+        this.owns = owns;
     }
 
     public String from() {
@@ -42,6 +44,10 @@ public final class Association implements Relationship {
 
     public Optional<String> propertyOrParameterName() {
         return propertyOrParameterName;
+    }
+    
+    public boolean owns() {
+        return owns;
     }
 
     @Override
@@ -79,6 +85,7 @@ public final class Association implements Relationship {
         private Optional<String> propertyOrParameterName = Optional.empty();
         private Optional<String> responseCode = Optional.empty();
         private Optional<String> responseContentType = Optional.empty();
+        private boolean  owns = false;
 
         Builder(String from) {
             this.from = from;
@@ -114,7 +121,7 @@ public final class Association implements Relationship {
             b.type = type;
             return new Builder3(b);
         }
-
+        
     }
 
     public static final class Builder3 {
@@ -127,7 +134,7 @@ public final class Association implements Relationship {
 
         public Association build() {
             return new Association(b.from, b.to, b.type, b.responseCode, b.responseContentType,
-                    b.propertyOrParameterName);
+                    b.propertyOrParameterName, b.owns);
         }
 
         public Builder3 propertyOrParameterName(String label) {
@@ -146,6 +153,15 @@ public final class Association implements Relationship {
 
         public Builder3 propertyOrParameterName(Optional<String> propertyOrParameterName) {
             b.propertyOrParameterName = propertyOrParameterName;
+            return this;
+        }
+        
+        public Builder3 owns() {
+            return owns(true);
+        }
+        
+        public Builder3 owns(boolean owns) {
+            b.owns = owns;
             return this;
         }
     }

--- a/src/main/java/com/github/davidmoten/oas3/internal/model/Association.java
+++ b/src/main/java/com/github/davidmoten/oas3/internal/model/Association.java
@@ -155,10 +155,6 @@ public final class Association implements Relationship {
             return this;
         }
 
-        public Builder3 owns() {
-            return owns(true);
-        }
-
         public Builder3 owns(boolean owns) {
             b.owns = owns;
             return this;

--- a/src/main/java/com/github/davidmoten/oas3/puml/Converter.java
+++ b/src/main/java/com/github/davidmoten/oas3/puml/Converter.java
@@ -127,12 +127,12 @@ public final class Converter {
                 final String label;
                 final String arrow;
                 if (a.responseCode().isPresent()) {
-                    arrow = "..>";
+                    arrow = (a.owns() ? "*":"") + "..>";
                     label = a.responseCode().get() + a.responseContentType()
                             .filter(x -> !"application/json".equalsIgnoreCase(x))
                             .map(x -> SPACE + x).orElse("");
                 } else {
-                    arrow = "-->";
+                    arrow = (a.owns() ? "*":"") + "-->";
                     label = a.propertyOrParameterName().orElse("");
                 }
                 String to = a.to();

--- a/src/main/java/com/github/davidmoten/oas3/puml/Converter.java
+++ b/src/main/java/com/github/davidmoten/oas3/puml/Converter.java
@@ -127,12 +127,12 @@ public final class Converter {
                 final String label;
                 final String arrow;
                 if (a.responseCode().isPresent()) {
-                    arrow = (a.owns() ? "*":"") + "..>";
+                    arrow = (a.owns() ? "*" : "") + "..>";
                     label = a.responseCode().get() + a.responseContentType()
                             .filter(x -> !"application/json".equalsIgnoreCase(x))
                             .map(x -> SPACE + x).orElse("");
                 } else {
-                    arrow = (a.owns() ? "*":"") + "-->";
+                    arrow = (a.owns() ? "*" : "") + "-->";
                     label = a.propertyOrParameterName().orElse("");
                 }
                 String to = a.to();

--- a/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
+++ b/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +38,6 @@ public class ConverterBatchTest {
         } else {
             List<File> result = Arrays.asList(list);
             Collections.sort(result, (a, b) -> a.getName().compareTo(b.getName()));
-//            result = result.stream().filter(x -> x.getName().startsWith("additional-properties-complex")).collect(Collectors.toList());
             return result;
         }
     }

--- a/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
+++ b/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +39,7 @@ public class ConverterBatchTest {
         } else {
             List<File> result = Arrays.asList(list);
             Collections.sort(result, (a, b) -> a.getName().compareTo(b.getName()));
+            result = result.stream().filter(x -> x.getName().startsWith("additional")).collect(Collectors.toList());
             return result;
         }
     }

--- a/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
+++ b/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
@@ -39,7 +39,7 @@ public class ConverterBatchTest {
         } else {
             List<File> result = Arrays.asList(list);
             Collections.sort(result, (a, b) -> a.getName().compareTo(b.getName()));
-            result = result.stream().filter(x -> x.getName().startsWith("additional")).collect(Collectors.toList());
+//            result = result.stream().filter(x -> x.getName().startsWith("additional-properties-complex")).collect(Collectors.toList());
             return result;
         }
     }

--- a/src/test/resources/inputs/additional-properties-complex.yml
+++ b/src/test/resources/inputs/additional-properties-complex.yml
@@ -1,0 +1,28 @@
+openapi: 3.0.1
+info:
+  title: unit test
+  version: 0.0.1
+components:
+  schemas:
+    Thing:
+      properties:
+        name: 
+          type: string
+        description:
+          type: string
+        property:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/MyValue"
+      required:
+      - name
+    MyValue:
+      properties:
+         name: 
+           type: string
+         expiry:
+           type: string
+           format: date-time
+      required:
+      - name
+      - expiry

--- a/src/test/resources/inputs/additional-properties-simple.yml
+++ b/src/test/resources/inputs/additional-properties-simple.yml
@@ -6,10 +6,6 @@ components:
   schemas:
     Customer:
       properties:
-        firstName:
-          type: string
-        lastName:
-          type: string
         property:
           type: object
           additionalProperties:

--- a/src/test/resources/inputs/additional-properties-simple.yml
+++ b/src/test/resources/inputs/additional-properties-simple.yml
@@ -1,0 +1,19 @@
+openapi: 3.0.1
+info:
+  title: unit test
+  version: 0.0.1
+components:
+  schemas:
+    Customer:
+      properties:
+        firstName:
+          type: string
+        lastName:
+          type: string
+        property:
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - firstName
+        - lastName

--- a/src/test/resources/inputs/additional-properties-simple.yml
+++ b/src/test/resources/inputs/additional-properties-simple.yml
@@ -4,12 +4,9 @@ info:
   version: 0.0.1
 components:
   schemas:
-    Customer:
+    Thing:
       properties:
         property:
           type: object
           additionalProperties:
             type: string
-      required:
-        - firstName
-        - lastName

--- a/src/test/resources/outputs/additional-properties-complex.puml
+++ b/src/test/resources/outputs/additional-properties-complex.puml
@@ -1,0 +1,27 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+set namespaceSeparator none
+
+class "Thing.property" {
+  {field} key : string
+}
+
+class "Thing" {
+  {field} name : string
+  {field} description : string {O}
+}
+
+class "MyValue" {
+  {field} name : string
+  {field} expiry : timestamp
+}
+
+"Thing" *--> "*" "Thing.property"  :  "property"
+
+"Thing.property" --> "1" "MyValue"  :  "value"
+
+@enduml

--- a/src/test/resources/outputs/additional-properties-simple.puml
+++ b/src/test/resources/outputs/additional-properties-simple.puml
@@ -7,9 +7,7 @@ hide empty fields
 set namespaceSeparator none
 
 class "Customer" {
-  {field} firstName : string
-  {field} lastName : string
-  {field} property : map {O}
+  {field} property : map
 }
 
 @enduml

--- a/src/test/resources/outputs/additional-properties-simple.puml
+++ b/src/test/resources/outputs/additional-properties-simple.puml
@@ -1,0 +1,15 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} property : map {O}
+}
+
+@enduml

--- a/src/test/resources/outputs/additional-properties-simple.puml
+++ b/src/test/resources/outputs/additional-properties-simple.puml
@@ -6,8 +6,8 @@ hide empty methods
 hide empty fields
 set namespaceSeparator none
 
-class "Customer" {
-  {field} property : map
+class "Thing" {
+  {field} property : string -> string
 }
 
 @enduml

--- a/src/test/resources/outputs/anon-nested-class-level.puml
+++ b/src/test/resources/outputs/anon-nested-class-level.puml
@@ -19,8 +19,8 @@ class "Customer" {
   {field} heightMetres : decimal {O}
 }
 
-"Customer.name" --> "0..1" "Customer.name.standardName"  :  "standardName"
+"Customer.name" *--> "0..1" "Customer.name.standardName"  :  "standardName"
 
-"Customer" --> "1" "Customer.name"  :  "name"
+"Customer" *--> "1" "Customer.name"  :  "name"
 
 @enduml

--- a/src/test/resources/outputs/anon-property-not-required.puml
+++ b/src/test/resources/outputs/anon-property-not-required.puml
@@ -15,6 +15,6 @@ class "Customer" {
   {field} heightMetres : decimal {O}
 }
 
-"Customer" --> "0..1" "Customer.name"  :  "name"
+"Customer" *--> "0..1" "Customer.name"  :  "name"
 
 @enduml

--- a/src/test/resources/outputs/anon-property-required.puml
+++ b/src/test/resources/outputs/anon-property-required.puml
@@ -15,6 +15,6 @@ class "Customer" {
   {field} heightMetres : decimal {O}
 }
 
-"Customer" --> "1" "Customer.name"  :  "name"
+"Customer" *--> "1" "Customer.name"  :  "name"
 
 @enduml


### PR DESCRIPTION
As discussed in #127, this PR adds support for displaying uml associated with `addtionalProperties` elements (maps with string based keys).

This PR also adds a composition marker to the association line between classes when a type is effectively embedded in another.