### PR TITLE
new configuration includeRelationFields

### DIFF
--- a/openapi-to-plantuml-maven-plugin/src/main/java/org/davidmoten/oa3/plantuml/plugin/GenerateMojo.java
+++ b/openapi-to-plantuml-maven-plugin/src/main/java/org/davidmoten/oa3/plantuml/plugin/GenerateMojo.java
@@ -52,6 +52,13 @@ public final class GenerateMojo extends AbstractMojo {
     @Parameter(name = "output")
     private File output;
 
+    /**
+     * Include relation fields in the generated class diagram?
+     * When true relations are both displayed as relations and displayed as class fields.
+     */
+    @Parameter(name = "includeRelationFields")
+    private boolean includeRelationFields = false;
+
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
@@ -74,12 +81,12 @@ public final class GenerateMojo extends AbstractMojo {
                 out = output;
             }
             getLog().info("Generating diagram in format=" + format //
-                    + " with style=" + style + " to " + out);
+                    + " with style=" + style + " to " + out + " with includeRelationFields=" + includeRelationFields);
             try {
                 if (style == Style.SINGLE) {
-                    Converter.writeSingleFile(input, format, out);
+                    Converter.writeSingleFile(input, format, out, includeRelationFields);
                 } else {
-                    Converter.writeSplitFiles(input, format, out);
+                    Converter.writeSplitFiles(input, format, out, includeRelationFields);
                 }
             } catch (IOException e) {
                 throw new MojoExecutionException("Error generating diagrams", e);

--- a/openapi-to-plantuml/pom.xml
+++ b/openapi-to-plantuml/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>2.1.38</version>
+            <version>2.1.42</version>
         </dependency>
         
         <dependency>

--- a/openapi-to-plantuml/src/main/checkstyle/checkstyle.xml
+++ b/openapi-to-plantuml/src/main/checkstyle/checkstyle.xml
@@ -130,7 +130,9 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See https://checkstyle.org/config_sizes.html -->
-        <module name="MethodLength"/>
+        <module name="MethodLength">
+            <property name="max" value="200"/>
+        </module>
 <!--         <module name="ParameterNumber"/> -->
 
         <!-- Checks for whitespace                               -->

--- a/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/Common.java
+++ b/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/Common.java
@@ -51,7 +51,8 @@ final class Common {
             .map(x -> x.toString().replace("[]", "")) //
             .collect(Collectors.toSet());
 
-    static Model toModelClass(String name, Schema<?> schema, Names names, ClassType classType) {
+    static Model toModelClass(String name, Schema<?> schema, Names names, ClassType classType,
+            boolean includeRelationFields) {
         List<Field> fields = new ArrayList<>();
         boolean isEnum = false;
         List<Relationship> relationships = new ArrayList<>();
@@ -62,11 +63,12 @@ final class Common {
             relationships.add(Association.from(name).to(otherClassName).one().build());
         }
         if (schema.getOneOf() != null) {
-            addInheritance(classes, relationships, name, schema.getOneOf(), names);
+            addInheritance(classes, relationships, name, schema.getOneOf(), names, includeRelationFields);
         } else if (schema.getAnyOf() != null) {
-            addInheritance(classes, relationships, name, schema.getAnyOf(), names);
+            addInheritance(classes, relationships, name, schema.getAnyOf(), names, includeRelationFields);
         } else if (schema.getAllOf() != null) {
-            addMixedTypeAll(classes, relationships, name, schema.getAllOf(), null, names);
+            addMixedTypeAll(classes, relationships, name, schema.getAllOf(), null,
+                    names, fields, new HashSet<>(), includeRelationFields);
         }
         if (schema.getProperties() != null) {
             final Set<String> required;
@@ -101,31 +103,46 @@ final class Common {
                     }
                     if (!list.isEmpty()) {
                         if (isAll) {
-                            addMixedTypeAll(classes, relationships, name, list, property, names);
+                            addMixedTypeAll(classes, relationships, name, list, property, names, fields, required,
+                                    includeRelationFields);
                         } else {
                             addInheritanceForProperty(classes, relationships, name, list, property,
-                                    associationType, names);
+                                    associationType, names, fields, required, includeRelationFields);
                         }
                     }
-                } else if (sch.get$ref() != null) {
+                }
+                if (sch.get$ref() != null) {
                     String ref = sch.get$ref();
                     String otherClassName = names.refToClassName(ref).className();
                     addToOne(relationships, name, otherClassName, property,
                             required.contains(entry.getKey()), false);
+                    if (includeRelationFields) {
+                        fields.add(new Field(entry.getKey(), otherClassName, false,
+                                required.contains(entry.getKey())));
+                    }
                 } else {
                     Optional<String> t = getUmlTypeName(sch, names);
                     if (t.isPresent()) {
                         String type = t.get();
                         if (isComplexArrayType(type)) {
-                            addArray(name, classes, relationships, property, sch, names);
+                            String otherClassname = addArray(name, classes, relationships, property, sch, names,
+                                    includeRelationFields);
+                            if (includeRelationFields) {
+                                fields.add(new Field(property, otherClassname + "[]", true,
+                                        true));
+                            }
                         } else if (type.equals("object")) {
                             // create anon class
                             String otherClassName = names.nextClassName(name + "." + property);
-                            Model m = toModelClass(otherClassName, sch, names, classType);
+                            Model m = toModelClass(otherClassName, sch, names, classType, includeRelationFields);
                             classes.addAll(m.classes());
                             relationships.addAll(m.relationships());
                             addToOne(relationships, name, otherClassName, property,
                                     required.contains(property), true);
+                            if (includeRelationFields) {
+                                fields.add(new Field(entry.getKey(), otherClassName, false,
+                                        required.contains(entry.getKey())));
+                            }
                         } else if (type.equals("map")) {
                             Object additionalProperties = sch.getAdditionalProperties();
                             if (additionalProperties instanceof Boolean) {
@@ -138,15 +155,20 @@ final class Common {
                                 ObjectSchema keySchema = new ObjectSchema();
                                 keySchema.addProperty("key", new StringSchema());
                                 keySchema.addRequiredItem("key");
-                                Model m = toModelClass(keyClassName, keySchema, names, ClassType.SCHEMA);
+                                Model m = toModelClass(keyClassName, keySchema, names, ClassType.SCHEMA,
+                                        includeRelationFields);
                                 classes.addAll(m.classes());
                                 relationships.addAll(m.relationships());
                                 addToMany(relationships, name, keyClassName, property, true);
                                 String valueClassName = names.refToClassName(valueSchema.get$ref()).className();
                                 addToOne(relationships, keyClassName, valueClassName, "value", true, false);
+                                if (includeRelationFields) {
+                                    fields.add(new Field(entry.getKey(), valueClassName, false,
+                                            required.contains(entry.getKey())));
+                                }
                             } else {
-                                fields.add(new Field(entry.getKey(), "string -> string", type.endsWith("]"),
-                                        true));
+                                // @todo I think required should be required.contains(entry.getKey())));
+                                fields.add(new Field(entry.getKey(), "string -> string", false, true));
                             }
                         } else if (!(entry.getValue() instanceof ComposedSchema)) {
                             fields.add(new Field(entry.getKey(), type, type.endsWith("]"),
@@ -155,7 +177,8 @@ final class Common {
                     }
                 }
             });
-        } else if (schema.getItems() != null) {
+        }
+        if (schema.getItems() != null) {
             Schema<?> items = schema.getItems();
             String ref = items.get$ref();
             String otherClassName;
@@ -164,12 +187,13 @@ final class Common {
             } else {
                 // create anon class
                 otherClassName = names.nextClassName(name);
-                Model m = toModelClass(otherClassName, items, names, classType);
+                Model m = toModelClass(otherClassName, items, names, classType, includeRelationFields);
                 classes.addAll(m.classes());
                 relationships.addAll(m.relationships());
             }
             addToMany(relationships, name, otherClassName);
         } else if (!(schema instanceof ObjectSchema)
+                && !(schema.getTypes() != null && schema.getTypes().contains("object"))
                 && schema.get$ref() == null
                 && schema.getOneOf() == null
                 && schema.getAnyOf() == null
@@ -205,8 +229,8 @@ final class Common {
         return SIMPLE_TYPES_WITHOUT_BRACKETS.contains(s.replace("[", "").replace("]", ""));
     }
 
-    private static void addArray(String name, List<Class> classes, List<Relationship> relationships,
-            String property, Schema a, Names names) {
+    private static String addArray(String name, List<Class> classes, List<Relationship> relationships,
+            String property, Schema<?> a, Names names, boolean includeRelationFields) {
         Preconditions.checkNotNull(property);
         // is array of items
         Schema<?> items = a.getItems();
@@ -217,45 +241,60 @@ final class Common {
         } else {
             // create anon class
             otherClassName = names.nextClassName(name + "." + property);
-            Model m = toModelClass(otherClassName, items, names, ClassType.SCHEMA);
+            Model m = toModelClass(otherClassName, items, names, ClassType.SCHEMA, includeRelationFields);
             classes.addAll(m.classes());
             relationships.addAll(m.relationships());
         }
         addToMany(relationships, name, otherClassName, property);
+        return otherClassName;
     }
 
     private static void addMixedTypeAll(List<Class> classes, List<Relationship> relationships,
             String name, @SuppressWarnings("rawtypes") List<Schema> schemas, String propertyName,
-            Names names) {
+            Names names,
+            List<Field> fields, Set<String> required,
+            boolean includeRelationFields) {
         List<String> otherClassNames = addAnonymousClassesAndReturnOtherClassNames(classes,
-                relationships, name, schemas, names, propertyName);
+                relationships, name, schemas, names, propertyName, includeRelationFields);
         for (String otherClassName : otherClassNames) {
             addToOne(relationships, name, otherClassName, propertyName, true, false);
+            if (includeRelationFields && propertyName != null) {
+                fields.add(new Field(propertyName, otherClassName, otherClassName.endsWith("]"),
+                        required.contains(propertyName)));
+            }
         }
     }
 
     private static void addInheritanceForProperty(List<Class> classes,
             List<Relationship> relationships, String name,
             @SuppressWarnings("rawtypes") List<Schema> schemas, String propertyName,
-            AssociationType associationType, Names names) {
+            AssociationType associationType, Names names,
+            List<Field> fields, Set<String> required,
+            boolean includeRelationFields) {
         List<String> otherClassNames = addAnonymousClassesAndReturnOtherClassNames(classes,
-                relationships, name, schemas, names, propertyName);
+                relationships, name, schemas, names, propertyName, includeRelationFields);
         Inheritance inheritance = new Inheritance(name, otherClassNames, associationType,
                 Optional.of(propertyName));
         relationships.add(inheritance);
+        if (includeRelationFields) {
+            fields.add(new Field(propertyName, otherClassNames.get(0), otherClassNames.get(0).endsWith("]"),
+                    required.contains(propertyName)));
+        }
     }
 
     private static void addInheritance(List<Class> classes, List<Relationship> relationships,
-            String name, @SuppressWarnings("rawtypes") List<Schema> schemas, Names names) {
+            String name, @SuppressWarnings("rawtypes") List<Schema> schemas, Names names,
+            boolean includeRelationFields) {
         List<String> otherClassNames = addAnonymousClassesAndReturnOtherClassNames(classes,
-                relationships, name, schemas, names, null);
+                relationships, name, schemas, names, null, includeRelationFields);
         relationships
                 .add(new Inheritance(name, otherClassNames, AssociationType.ONE, Optional.empty()));
     }
 
     private static List<String> addAnonymousClassesAndReturnOtherClassNames(List<Class> classes,
             List<Relationship> relationships, String name,
-            @SuppressWarnings("rawtypes") List<Schema> schemas, Names names, String property) {
+            @SuppressWarnings("rawtypes") List<Schema> schemas, Names names, String property,
+            boolean includeRelationFields) {
         List<String> otherClassNames = schemas.stream() //
                 .map(s -> {
                     if (s.get$ref() != null) {
@@ -263,7 +302,7 @@ final class Common {
                     } else {
                         String className = names
                                 .nextClassName(name + (property == null ? "" : "." + property));
-                        Model m = toModelClass(className, s, names, ClassType.SCHEMA);
+                        Model m = toModelClass(className, s, names, ClassType.SCHEMA, includeRelationFields);
                         classes.addAll(m.classes());
                         relationships.addAll(m.relationships());
                         return className;
@@ -360,6 +399,8 @@ final class Common {
                     type = "decimal";
                 } else if (types.contains("boolean")) {
                     type = "boolean";
+                } else if (types.contains("array")) {
+                    type = "object[]"; // Best guess
                 } else if (types.contains("object")) {
                     type = "object";
                 } else {

--- a/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/Common.java
+++ b/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/Common.java
@@ -60,18 +60,15 @@ final class Common {
             // this is an alias case for a schema
             String otherClassName = names.refToClassName(schema.get$ref()).className();
             relationships.add(Association.from(name).to(otherClassName).one().build());
-        } else if (schema instanceof ComposedSchema) {
-            ComposedSchema s = (ComposedSchema) schema;
-            if (s.getOneOf() != null) {
-                addInheritance(classes, relationships, name, s.getOneOf(), names);
-            } else if (s.getAnyOf() != null) {
-                addInheritance(classes, relationships, name, s.getAnyOf(), names);
-            } else if (s.getAllOf() != null) {
-                addMixedTypeAll(classes, relationships, name, s.getAllOf(), null, names);
-            } else {
-                throw new RuntimeException("unexpected");
-            }
-        } else if (schema.getProperties() != null) {
+        }
+        if (schema.getOneOf() != null) {
+            addInheritance(classes, relationships, name, schema.getOneOf(), names);
+        } else if (schema.getAnyOf() != null) {
+            addInheritance(classes, relationships, name, schema.getAnyOf(), names);
+        } else if (schema.getAllOf() != null) {
+            addMixedTypeAll(classes, relationships, name, schema.getAllOf(), null, names);
+        }
+        if (schema.getProperties() != null) {
             final Set<String> required;
             if (schema.getRequired() != null) {
                 required = new HashSet<>(schema.getRequired());
@@ -81,21 +78,20 @@ final class Common {
             schema.getProperties().entrySet().forEach(entry -> {
                 String property = entry.getKey();
                 Schema<?> sch = entry.getValue();
-                if (sch instanceof ComposedSchema) {
-                    ComposedSchema s = (ComposedSchema) sch;
+                if (sch.getOneOf() != null || sch.getAnyOf() != null || sch.getAllOf() != null) {
                     @SuppressWarnings("rawtypes")
                     final List<Schema> list;
                     final AssociationType associationType;
                     boolean req = required.contains(property);
                     boolean isAll = false;
-                    if (s.getOneOf() != null) {
-                        list = s.getOneOf();
+                    if (sch.getOneOf() != null) {
+                        list = sch.getOneOf();
                         associationType = req ? AssociationType.ONE : AssociationType.ZERO_ONE;
-                    } else if (s.getAnyOf() != null) {
-                        list = s.getAnyOf();
+                    } else if (sch.getAnyOf() != null) {
+                        list = sch.getAnyOf();
                         associationType = req ? AssociationType.ONE : AssociationType.ZERO_ONE;
-                    } else if (s.getAllOf() != null) {
-                        list = s.getAllOf();
+                    } else if (sch.getAllOf() != null) {
+                        list = sch.getAllOf();
                         isAll = true;
                         associationType = null;
                     } else {
@@ -121,8 +117,7 @@ final class Common {
                     if (t.isPresent()) {
                         String type = t.get();
                         if (isComplexArrayType(type)) {
-                            addArray(name, classes, relationships, property, (ArraySchema) sch,
-                                    names);
+                            addArray(name, classes, relationships, property, sch, names);
                         } else if (type.equals("object")) {
                             // create anon class
                             String otherClassName = names.nextClassName(name + "." + property);
@@ -132,12 +127,12 @@ final class Common {
                             addToOne(relationships, name, otherClassName, property,
                                     required.contains(property), true);
                         } else if (type.equals("map")) {
-                            MapSchema ms = (MapSchema) sch;
-                            if (ms.getAdditionalProperties() instanceof Boolean) {
+                            Object additionalProperties = sch.getAdditionalProperties();
+                            if (additionalProperties instanceof Boolean) {
                                 // TODO what if Boolean.FALSE?
-                                ms.setAdditionalProperties(new Schema<>());
+                                sch.setAdditionalProperties(new Schema<>());
                             }
-                            Schema<?> valueSchema = ((Schema<?>) ms.getAdditionalProperties());
+                            Schema<?> valueSchema = (Schema<?>) sch.getAdditionalProperties();
                             if (valueSchema.get$ref() != null) {
                                 String keyClassName = names.nextClassName(name + "." + property);
                                 ObjectSchema keySchema = new ObjectSchema();
@@ -153,16 +148,15 @@ final class Common {
                                 fields.add(new Field(entry.getKey(), "string -> string", type.endsWith("]"),
                                         true));
                             }
-                        } else {
+                        } else if (!(entry.getValue() instanceof ComposedSchema)) {
                             fields.add(new Field(entry.getKey(), type, type.endsWith("]"),
                                     required.contains(entry.getKey())));
                         }
                     }
                 }
             });
-        } else if (schema instanceof ArraySchema) {
-            ArraySchema a = (ArraySchema) schema;
-            Schema<?> items = a.getItems();
+        } else if (schema.getItems() != null) {
+            Schema<?> items = schema.getItems();
             String ref = items.get$ref();
             String otherClassName;
             if (ref != null) {
@@ -175,7 +169,11 @@ final class Common {
                 relationships.addAll(m.relationships());
             }
             addToMany(relationships, name, otherClassName);
-        } else if (!(schema instanceof ObjectSchema)) {
+        } else if (!(schema instanceof ObjectSchema)
+                && schema.get$ref() == null
+                && schema.getOneOf() == null
+                && schema.getAnyOf() == null
+                && schema.getAllOf() == null) {
             // has no properties so ignore ObjectSchema
             Optional<String> t = getUmlTypeName(schema, names);
             if (t.isPresent()) {
@@ -208,7 +206,7 @@ final class Common {
     }
 
     private static void addArray(String name, List<Class> classes, List<Relationship> relationships,
-            String property, ArraySchema a, Names names) {
+            String property, Schema a, Names names) {
         Preconditions.checkNotNull(property);
         // is array of items
         Schema<?> items = a.getItems();
@@ -313,26 +311,25 @@ final class Common {
             type = names.refToClassName(ref).className();
         } else if (schema == null) {
             type = null;
+        } else if (schema instanceof BinarySchema || "binary".equals(schema.getFormat())) {
+            type = "byte[]";
+        } else if (schema instanceof ByteArraySchema || "byte".equals(schema.getFormat())) {
+            type = "byte[]";
         } else if (schema instanceof StringSchema) {
             type = "string";
         } else if (schema instanceof BooleanSchema) {
             type = "boolean";
-        } else if (schema instanceof DateTimeSchema) {
+        } else if (schema instanceof DateTimeSchema || "date-time".equals(schema.getFormat())) {
             type = "timestamp";
-        } else if (schema instanceof DateSchema) {
+        } else if (schema instanceof DateSchema || "date".equals(schema.getFormat())) {
             type = "date";
         } else if (schema instanceof NumberSchema) {
             type = "decimal";
         } else if (schema instanceof IntegerSchema) {
             type = "integer";
-        } else if (schema instanceof ArraySchema) {
-            ArraySchema a = (ArraySchema) schema;
-            type = getUmlTypeName(a.getItems(), names) //
+        } else if (schema instanceof ArraySchema || schema.getItems() != null) {
+            type = getUmlTypeName(schema.getItems(), names) //
                     .orElse("object") + "[]";
-        } else if (schema instanceof BinarySchema) {
-            type = "byte[]";
-        } else if (schema instanceof ByteArraySchema) {
-            type = "byte[]";
         } else if (schema instanceof ObjectSchema) {
             type = "object";
         } else if (schema instanceof FileSchema) {
@@ -343,19 +340,40 @@ final class Common {
             type = "string";
         } else if (schema instanceof UUIDSchema) {
             type = "string";
-        } else if (schema instanceof MapSchema) {
+        } else if (schema instanceof MapSchema
+                || (schema.getAdditionalProperties() != null
+                        && !(schema.getAdditionalProperties() instanceof Boolean))) {
             type = "map";
         } else if (schema instanceof ComposedSchema) {
             // TODO handle ComposedSchema
             type = "string";
-        } else if ("string".equals(schema.getType())) {
-            type = "string";
-        } else if (schema.get$ref() != null) {
-            type = names.refToClassName(schema.get$ref()).className();
-        } else if (schema.getType() == null) {
-            type = null;
         } else {
-            throw new RuntimeException("not expected" + schema);
+            Set<String> types = schema.getTypes();
+            if (types != null && !types.isEmpty()) {
+                if (types.contains("array")) {
+                    type = getUmlTypeName(schema.getItems(), names).orElse("object") + "[]";
+                } else if (types.contains("string")) {
+                    type = "string";
+                } else if (types.contains("integer")) {
+                    type = "integer";
+                } else if (types.contains("number")) {
+                    type = "decimal";
+                } else if (types.contains("boolean")) {
+                    type = "boolean";
+                } else if (types.contains("object")) {
+                    type = "object";
+                } else {
+                    type = types.iterator().next();
+                }
+            } else if ("string".equals(schema.getType())) {
+                type = "string";
+            } else if (schema.get$ref() != null) {
+                type = names.refToClassName(schema.get$ref()).className();
+            } else if (schema.getType() == null) {
+                type = null;
+            } else {
+                throw new RuntimeException("not expected" + schema);
+            }
         }
         return Optional.ofNullable(type);
     }

--- a/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/ComponentsHelper.java
+++ b/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/ComponentsHelper.java
@@ -24,7 +24,7 @@ public final class ComponentsHelper {
                 .stream() //
                 .map(entry -> Common.toModelClass(names.schemaClassName(entry.getKey()), entry.getValue(), names,
                         ClassType.SCHEMA)) //
-                .reduce(Model.EMPTY, (a, b) -> a.add(b));
+                .reduce(Model.EMPTY, Model::add);
 
         Model part2 = names //
                 .requestBodies() //
@@ -45,7 +45,7 @@ public final class ComponentsHelper {
                                 ClassType.REQUEST_BODY);
                     }
                 }) //
-                .reduce(Model.EMPTY, (a, b) -> a.add(b));
+                .reduce(Model.EMPTY, Model::add);
 
         Model part3 = names //
                 .parameters() //

--- a/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/ComponentsHelper.java
+++ b/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/ComponentsHelper.java
@@ -17,13 +17,13 @@ public final class ComponentsHelper {
         // prevent instantiation
     }
 
-    public static Model toModel(Names names) {
+    public static Model toModel(Names names, boolean includeRelationFields) {
         Model part1 = names //
                 .schemas() //
                 .entrySet() //
                 .stream() //
                 .map(entry -> Common.toModelClass(names.schemaClassName(entry.getKey()), entry.getValue(), names,
-                        ClassType.SCHEMA)) //
+                        ClassType.SCHEMA, includeRelationFields)) //
                 .reduce(Model.EMPTY, Model::add);
 
         Model part2 = names //
@@ -42,7 +42,7 @@ public final class ComponentsHelper {
                     } else {
                         return Common.toModelClass(names.requestBodyClassName(entry.getKey()),
                                 first(entry.getValue().getContent()).get().getValue().getSchema(), names,
-                                ClassType.REQUEST_BODY);
+                                ClassType.REQUEST_BODY, includeRelationFields);
                     }
                 }) //
                 .reduce(Model.EMPTY, Model::add);
@@ -61,7 +61,8 @@ public final class ComponentsHelper {
                         Association a = Association.from(className).to(otherClassName).one().build();
                         return new Model(c, a);
                     } else {
-                        return Common.toModelClass(className, p.getSchema(), names, ClassType.PARAMETER);
+                        return Common.toModelClass(className, p.getSchema(), names, ClassType.PARAMETER,
+                                includeRelationFields);
                     }
                 }) //
                 .reduce(Model.EMPTY, (a, b) -> a.add(b));
@@ -73,7 +74,7 @@ public final class ComponentsHelper {
                 // TODO handle ref responses as per parameters and request bodies above
                 .map(entry -> first(nullMapToEmpty(entry.getValue().getContent())) //
                         .map(x -> Common.toModelClass(names.responseClassName(entry.getKey()), x.getValue().getSchema(),
-                                names, ClassType.RESPONSE)) //
+                                names, ClassType.RESPONSE, includeRelationFields)) //
                         .orElse(new Model(new Class(names.responseClassName(entry.getKey()), ClassType.RESPONSE)))) //
                 .reduce(Model.EMPTY, (a, b) -> a.add(b));
 

--- a/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/PathsHelper.java
+++ b/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/internal/PathsHelper.java
@@ -34,11 +34,11 @@ public final class PathsHelper {
         // prevent instantiation
     }
 
-    public static Model toModel(Names names) {
-        return paths(names);
+    public static Model toModel(Names names, boolean includeRelationFields) {
+        return paths(names, includeRelationFields);
     }
 
-    private static Model paths(Names names) {
+    private static Model paths(Names names, boolean includeRelationFields) {
         if (names.paths() == null) {
             return Model.EMPTY;
         } else {
@@ -46,12 +46,12 @@ public final class PathsHelper {
                     .entrySet() //
                     .stream() //
                     .map(entry -> toModelPath(entry.getKey(), //
-                            entry.getValue(), names))
+                            entry.getValue(), names, includeRelationFields))
                     .reduce(Model.EMPTY, (a, b) -> a.add(b));
         }
     }
 
-    private static Model toModelPath(String path, PathItem p, Names names) {
+    private static Model toModelPath(String path, PathItem p, Names names, boolean includeRelationFields) {
         // add method class blocks with HTTP verb and parameters
         // add response lines
         return p.readOperationsMap() //
@@ -63,23 +63,23 @@ public final class PathsHelper {
                     String defaultClassName = entry.getKey() + " " + path;
                     String className = operationId.orElse(defaultClassName);
                     FieldsWithModel f = toModelParameters(names, className,
-                            operation.getParameters());
+                            operation.getParameters(), includeRelationFields);
                     Optional<String> description = operationId.isPresent() //
                             ? Optional.of(defaultClassName) : Optional.empty();
                     Model m = new Model(new Class(className, ClassType.METHOD, //
                             f.fields, false, description))
                             .add(f.model);
-                    m = m.add(toModelResponses(names, operation, className));
-                    return m.add(toModelRequestBody(className, operation, names));
+                    m = m.add(toModelResponses(names, operation, className, includeRelationFields));
+                    return m.add(toModelRequestBody(className, operation, names, includeRelationFields));
                 }) //
                 .reduce(Model.EMPTY, (a, b) -> a.add(b));
     }
 
     private static FieldsWithModel toModelParameters(Names names, String className,
-            List<Parameter> parameters) {
+            List<Parameter> parameters, boolean includeRelationFields) {
         return nullListToEmpty(parameters) //
                 .stream()//
-                .map(param -> toModelParameter(names, className, param)) //
+                .map(param -> toModelParameter(names, className, param, includeRelationFields)) //
                 .reduce(FieldsWithModel.EMPTY, (a, b) -> a.add(b));
     }
 
@@ -102,7 +102,7 @@ public final class PathsHelper {
     }
 
     private static FieldsWithModel toModelParameter(Names names, String className,
-            Parameter param) {
+            Parameter param, boolean includeRelationFields) {
         String ref = param.get$ref();
         String parameterName = param.getName();
         Boolean required = param.getRequired();
@@ -140,7 +140,7 @@ public final class PathsHelper {
                 final Model m;
                 if (param.getSchema() != null) {
                     m = Common.toModelClass(anonClassName, param.getSchema(), names,
-                            ClassType.PARAMETER);
+                            ClassType.PARAMETER, includeRelationFields);
                 } else {
                     m = new Model(new Class(anonClassName, ClassType.PARAMETER));
                 }
@@ -180,7 +180,8 @@ public final class PathsHelper {
         }
     }
 
-    private static Model toModelRequestBody(String className, Operation operation, Names names) {
+    private static Model toModelRequestBody(String className, Operation operation, Names names,
+            boolean includeRelationFields) {
         RequestBody body = operation.getRequestBody();
         if (body != null) {
             String ref = body.get$ref();
@@ -203,7 +204,7 @@ public final class PathsHelper {
                 } else {
                     requestBodyClassName = className + " Request";
                     model = Common.toModelClass(requestBodyClassName, sch, names,
-                            ClassType.REQUEST_BODY);
+                            ClassType.REQUEST_BODY, includeRelationFields);
                 }
                 Association a = Association.from(className).to(requestBodyClassName).one().build();
                 return model.add(a);
@@ -212,7 +213,8 @@ public final class PathsHelper {
         return Model.EMPTY;
     }
 
-    private static Model toModelResponses(Names names, Operation operation, String className) {
+    private static Model toModelResponses(Names names, Operation operation, String className,
+            boolean includeRelationFields) {
         return operation //
                 .getResponses() //
                 .entrySet() //
@@ -255,7 +257,7 @@ public final class PathsHelper {
                                 } else {
                                     String returnClassName = newReturnClassName;
                                     m = m.add(Common.toModelClass(returnClassName, sch, names,
-                                            ClassType.RESPONSE));
+                                            ClassType.RESPONSE, includeRelationFields));
                                     m = m.add(Association.from(className).to(returnClassName).one()
                                             .responseCode(responseCode)
                                             .responseContentType(contentType).build());

--- a/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/puml/Converter.java
+++ b/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/puml/Converter.java
@@ -57,19 +57,21 @@ public final class Converter {
         // prevent instantiation
     }
 
-    public static String openApiToPuml(InputStream in) throws IOException {
-        return openApiToPuml(in, ModelTransformer.identity()).puml();
+    public static String openApiToPuml(InputStream in, boolean includeRelationFields) throws IOException {
+        return openApiToPuml(in, ModelTransformer.identity(), includeRelationFields).puml();
     }
 
-    public static List<PumlExtract> openApiToPumlSplitByMethod(File file) throws IOException {
+    public static List<PumlExtract> openApiToPumlSplitByMethod(File file,
+            boolean includeRelationFields) throws IOException {
         try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
-            return openApiToPumlSplitByMethod(in);
+            return openApiToPumlSplitByMethod(in, includeRelationFields);
         }
     }
 
-    public static List<PumlExtract> openApiToPumlSplitByMethod(InputStream in) throws IOException {
+    public static List<PumlExtract> openApiToPumlSplitByMethod(InputStream in,
+            boolean includeRelationFields) throws IOException {
         OpenAPI api = parseOpenApi(IOUtils.toString(in, StandardCharsets.UTF_8));
-        Model m = toModel(api);
+        Model m = toModel(api, includeRelationFields);
         return m //
                 .classes() //
                 .stream() //
@@ -82,23 +84,26 @@ public final class Converter {
                 .collect(Collectors.toList());
     }
 
-    public static <T extends HasPuml> T openApiToPuml(InputStream in, ModelTransformer<T> transformer)
+    public static <T extends HasPuml> T openApiToPuml(InputStream in, ModelTransformer<T> transformer,
+            boolean includeRelationFields)
             throws IOException {
-        return openApiToPuml(IOUtils.toString(in, StandardCharsets.UTF_8), transformer);
+        return openApiToPuml(IOUtils.toString(in, StandardCharsets.UTF_8), transformer, includeRelationFields);
     }
 
-    public static String openApiToPuml(File file) throws IOException {
-        return openApiToPuml(file, ModelTransformer.identity()).puml();
+    public static String openApiToPuml(File file, boolean includeRelationFields) throws IOException {
+        return openApiToPuml(file, ModelTransformer.identity(), includeRelationFields).puml();
     }
 
-    public static <T extends HasPuml> T openApiToPuml(File file, ModelTransformer<T> transformer) throws IOException {
+    public static <T extends HasPuml> T openApiToPuml(File file, ModelTransformer<T> transformer,
+            boolean includeRelationFields) throws IOException {
         try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
-            return openApiToPuml(in, transformer);
+            return openApiToPuml(in, transformer, includeRelationFields);
         }
     }
 
-    public static <T extends HasPuml> T openApiToPuml(String openApi, ModelTransformer<T> transformer) {
-        return openApiToPuml(parseOpenApi(openApi), transformer);
+    public static <T extends HasPuml> T openApiToPuml(String openApi, ModelTransformer<T> transformer,
+            boolean includeRelationFields) {
+        return openApiToPuml(parseOpenApi(openApi), transformer, includeRelationFields);
     }
 
     private static OpenAPI parseOpenApi(String openApi) {
@@ -110,21 +115,22 @@ public final class Converter {
         return result.getOpenAPI();
     }
 
-    public static String openApiToPuml(String openApi) {
-        return openApiToPuml(openApi, ModelTransformer.identity()).puml();
+    public static String openApiToPuml(String openApi, boolean includeRelationFields) {
+        return openApiToPuml(openApi, ModelTransformer.identity(), includeRelationFields).puml();
     }
 
-    private static <T extends HasPuml> T openApiToPuml(OpenAPI a, ModelTransformer<T> transformer) {
-        Model m = toModel(a);
+    private static <T extends HasPuml> T openApiToPuml(OpenAPI a, ModelTransformer<T> transformer,
+            boolean includeRelationFields) {
+        Model m = toModel(a, includeRelationFields);
         Model model = transformer.apply(m);
         return transformer.createHasPuml(toPlantUml(model));
     }
 
-    private static Model toModel(OpenAPI a) {
+    private static Model toModel(OpenAPI a, boolean includeRelationFields) {
         Names names = new Names(a);
         return ComponentsHelper //
-                .toModel(names) //
-                .add(PathsHelper.toModel(names));
+                .toModel(names, includeRelationFields) //
+                .add(PathsHelper.toModel(names, includeRelationFields));
     }
 
     private static String toPlantUml(Model model) {
@@ -279,9 +285,10 @@ public final class Converter {
         return Optional.ofNullable(result);
     }
 
-    public static void writeSplitFiles(File inputFile, String format, File out) throws IOException {
+    public static void writeSplitFiles(File inputFile, String format, File out,
+            boolean includeRelationFields) throws IOException {
         out.mkdirs();
-        List<PumlExtract> list = Converter.openApiToPumlSplitByMethod(inputFile);
+        List<PumlExtract> list = Converter.openApiToPumlSplitByMethod(inputFile, includeRelationFields);
         for (PumlExtract puml : list) {
             String filename = puml.classNameFrom().iterator().next().replace(" ", "_").replace("/", "_")
                     .replace("\\", "_").replace("{", "").replace("}", "");
@@ -295,9 +302,10 @@ public final class Converter {
         }
     }
 
-    public static void writeSingleFile(File inputFile, String format, File out) throws IOException {
+    public static void writeSingleFile(File inputFile, String format, File out,
+            boolean includeRelationFields) throws IOException {
         out.getParentFile().mkdirs();
-        String puml = Converter.openApiToPuml(inputFile);
+        String puml = Converter.openApiToPuml(inputFile, includeRelationFields);
         if (format.equals("PUML")) {
             Files.write(out.toPath(), puml.getBytes(StandardCharsets.UTF_8));
         } else {

--- a/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/puml/ConverterMain.java
+++ b/openapi-to-plantuml/src/main/java/com/github/davidmoten/oas3/puml/ConverterMain.java
@@ -20,24 +20,26 @@ public final class ConverterMain {
 
     public static void main(String[] args) throws IOException {
         String usage = "Usage: java -jar openapi-to-plantuml-all.jar (single|split)"
-                + " <OPENAPI_FILE> <FILE_FORMAT> <OUTPUT_DIRECTORY>" + "\n  File formats are:\n"
+                + " <OPENAPI_FILE> <FILE_FORMAT> <OUTPUT_DIRECTORY> [include-relation-fields]"
+                + "\n  File formats are:\n"
                 + FILE_FORMATS.stream().map(x -> "    " + x + "\n").collect(Collectors.joining());
-        if (args.length != 4) {
+        if (args.length != 4 && args.length != 5) {
             System.out.println(usage);
-            throw new IllegalArgumentException("must pass 4 arguments");
+            throw new IllegalArgumentException("must pass 4 or 5 arguments");
         } else {
             Style style = Style.valueOf(args[0].toUpperCase(Locale.ENGLISH));
+            String inputFilename = args[1];
+            String format = args[2];
+            File out = new File(args[3]);
+            boolean includeRelationFields = false;
+            if (args.length == 5) {
+                includeRelationFields = Boolean.parseBoolean(args[4]);
+            }
             if (style == Style.SPLIT) {
-                String inputFilename = args[1];
-                String format = args[2];
-                File out = new File(args[3]);
                 out.mkdirs();
-                Converter.writeSplitFiles(new File(inputFilename), format, out);
+                Converter.writeSplitFiles(new File(inputFilename), format, out, includeRelationFields);
             } else {
-                String inputFilename = args[1];
-                String format = args[2];
-                File out = new File(args[3]);
-                Converter.writeSingleFile(new File(inputFilename), format, out);
+                Converter.writeSingleFile(new File(inputFilename), format, out, includeRelationFields);
             }
         }
     }

--- a/openapi-to-plantuml/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
+++ b/openapi-to-plantuml/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
@@ -23,6 +23,7 @@ public class ConverterBatchTest {
 
     private static final File INPUTS = new File("src/test/resources/inputs/");
     private static final File OUTPUTS = new File("src/test/resources/outputs/");
+    private static final File OUTPUTS_INC_RELATION_FIELDS = new File("src/test/resources/outputs-incl-rel-fields/");
 
     private final File input;
 
@@ -46,7 +47,7 @@ public class ConverterBatchTest {
     public void test30() {
         System.out.println("checking " + input);
         String inputData = com.github.davidmoten.junit.Files.readString(input, StandardCharsets.UTF_8);
-        test(inputData);
+        test(inputData, false);
     }
 
     @Test
@@ -54,18 +55,35 @@ public class ConverterBatchTest {
         System.out.println("checking " + input);
         String inputData = com.github.davidmoten.junit.Files.readString(input, StandardCharsets.UTF_8);
         inputData = inputData.replace("openapi: 3.0.1", "openapi: 3.1.0");
-        test(inputData);
+        test(inputData, false);
     }
 
-    private void test(String inputData) {
+    @Test
+    public void test30IncludeRelationFields() {
+        System.out.println("checking " + input);
+        String inputData = com.github.davidmoten.junit.Files.readString(input, StandardCharsets.UTF_8);
+        test(inputData, true);
+    }
+
+    @Test
+    public void test31IncludeRelationFields() {
+        System.out.println("checking " + input);
+        String inputData = com.github.davidmoten.junit.Files.readString(input, StandardCharsets.UTF_8);
+        inputData = inputData.replace("openapi: 3.0.1", "openapi: 3.1.0");
+        test(inputData, true);
+    }
+
+    private void test(String inputData, boolean includeRelationFields) {
         try (InputStream in = new ByteArrayInputStream(inputData.getBytes())) {
-            String puml = Converter.openApiToPuml(in).trim();
+            String puml = Converter.openApiToPuml(in, includeRelationFields).trim();
             File pumlFile = new File("target/outputs",
                     input.getName().substring(0, input.getName().lastIndexOf('.')) + ".puml");
             pumlFile.getParentFile().mkdirs();
             pumlFile.delete();
             Files.write(pumlFile.toPath(), puml.getBytes(StandardCharsets.UTF_8));
-            File output = new File(OUTPUTS, input.getName().substring(0, input.getName().lastIndexOf('.')) + ".puml");
+            File outputsPath = includeRelationFields ? OUTPUTS_INC_RELATION_FIELDS : OUTPUTS;
+            String outputsName = input.getName().substring(0, input.getName().lastIndexOf('.')) + ".puml";
+            File output = new File(outputsPath, outputsName);
             if (!output.exists()) {
                 output.createNewFile();
                 System.out.println(puml);

--- a/openapi-to-plantuml/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
+++ b/openapi-to-plantuml/src/test/java/com/github/davidmoten/oas3/puml/ConverterBatchTest.java
@@ -1,9 +1,11 @@
 package com.github.davidmoten.oas3.puml;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -14,9 +16,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class ConverterBatchTest {
@@ -43,9 +43,22 @@ public class ConverterBatchTest {
     }
 
     @Test
-    public void test() {
+    public void test30() {
         System.out.println("checking " + input);
-        try (InputStream in = new FileInputStream(input)) {
+        String inputData = com.github.davidmoten.junit.Files.readString(input, StandardCharsets.UTF_8);
+        test(inputData);
+    }
+
+    @Test
+    public void test31() {
+        System.out.println("checking " + input);
+        String inputData = com.github.davidmoten.junit.Files.readString(input, StandardCharsets.UTF_8);
+        inputData = inputData.replace("openapi: 3.0.1", "openapi: 3.1.0");
+        test(inputData);
+    }
+
+    private void test(String inputData) {
+        try (InputStream in = new ByteArrayInputStream(inputData.getBytes())) {
             String puml = Converter.openApiToPuml(in).trim();
             File pumlFile = new File("target/outputs",
                     input.getName().substring(0, input.getName().lastIndexOf('.')) + ".puml");

--- a/openapi-to-plantuml/src/test/java/com/github/davidmoten/oas3/puml/ConverterTest.java
+++ b/openapi-to-plantuml/src/test/java/com/github/davidmoten/oas3/puml/ConverterTest.java
@@ -43,17 +43,17 @@ public class ConverterTest {
                 + "          type: array\n" + "          items:\n"
                 + "            $ref: '#/components/schemas/Customer'\n" + "      ";
 
-        Converter.openApiToPuml(openapi);
+        Converter.openApiToPuml(openapi, false);
     }
 
     @Test
     public void testConvertExternalRef() throws IOException {
-        Converter.openApiToPuml(new File("src/test/resources/inputs/external-ref.yml"));
+        Converter.openApiToPuml(new File("src/test/resources/inputs/external-ref.yml"), false);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConvertEmpty() {
-        Converter.openApiToPuml("");
+        Converter.openApiToPuml("", false);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class ConverterTest {
 
     static void writeSvg(File openApiFile, String filename) throws IOException {
         try (InputStream in = new FileInputStream(openApiFile)) {
-            String puml = Converter.openApiToPuml(in);
+            String puml = Converter.openApiToPuml(in, false);
             writeSvgFromPuml(puml, filename);
         }
     }

--- a/openapi-to-plantuml/src/test/java/com/github/davidmoten/oas3/puml/DemoBatchTest.java
+++ b/openapi-to-plantuml/src/test/java/com/github/davidmoten/oas3/puml/DemoBatchTest.java
@@ -51,7 +51,7 @@ public class DemoBatchTest {
             File svg = new File(demos, input.getName().substring(0, input.getName().lastIndexOf('.')) + ".svg");
             String puml;
             try (InputStream def = new FileInputStream(input)) {
-                puml = com.github.davidmoten.oas3.puml.Converter.openApiToPuml(def);
+                puml = com.github.davidmoten.oas3.puml.Converter.openApiToPuml(def, false);
             }
             File pumlFile = new File(demos, input.getName().substring(0, input.getName().lastIndexOf('.')) + ".puml");
             pumlFile.delete();

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/additional-properties-complex.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/additional-properties-complex.puml
@@ -1,0 +1,31 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "MyValue" {
+  {field} name : string
+  {field} expiry : timestamp
+}
+
+class "Thing" {
+  {field} name : string
+  {field} description : string {O}
+  {field} property : MyValue {O}
+}
+
+class "Thing.property" {
+  {field} key : string
+}
+
+"Thing" *--> "*" "Thing.property"  :  "property"
+
+"Thing.property" --> "1" "MyValue"  :  "value"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/additional-properties-simple.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/additional-properties-simple.puml
@@ -1,0 +1,16 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Thing" {
+  {field} property : string -> string
+}
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/all-of-class-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/all-of-class-level.puml
@@ -1,0 +1,27 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "doctor" {
+  {field} income : decimal
+}
+
+class "employee" {
+}
+
+class "nurse" {
+  {field} level : integer
+}
+
+"employee" --> "1" "doctor"
+
+"employee" --> "1" "nurse"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/all-of-property-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/all-of-property-level.puml
@@ -1,0 +1,29 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "doctor" {
+  {field} income : decimal
+}
+
+class "employee" {
+  {field} role : doctor {O}
+  {field} role : nurse {O}
+}
+
+class "nurse" {
+  {field} level : integer
+}
+
+"employee" --> "1" "doctor"  :  "role"
+
+"employee" --> "1" "nurse"  :  "role"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/anon-nested-class-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/anon-nested-class-level.puml
@@ -1,0 +1,31 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} name : Customer.name
+  {field} heightMetres : decimal {O}
+}
+
+class "Customer.name" {
+  {field} standardName : Customer.name.standardName {O}
+  {field} origin : string {O}
+}
+
+class "Customer.name.standardName" {
+  {field} firstName : string
+  {field} lastName : string
+}
+
+"Customer.name" *--> "0..1" "Customer.name.standardName"  :  "standardName"
+
+"Customer" *--> "1" "Customer.name"  :  "name"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/anon-parameters.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/anon-parameters.puml
@@ -1,0 +1,25 @@
+@startuml
+set namespaceSeparator none
+
+class "Customer" {
+  firstName : string {O}
+  lastName : string {O}
+}
+
+class "CustomerId" <<Parameter>> {
+  value : string
+}
+hide <<Method>> circle
+
+class "GET /customer/expired" <<Method>> {
+  customerId : string
+}
+
+class "GET /customer/expired 200 Response" <<Response>> {
+}
+
+"GET /customer/expired 200 Response" --> "*" "Customer"
+
+"GET /customer/expired" ..> "GET /customer/expired 200 Response": 200
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/anon-property-not-required.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/anon-property-not-required.puml
@@ -1,0 +1,24 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} name : Customer.name {O}
+  {field} heightMetres : decimal {O}
+}
+
+class "Customer.name" {
+  {field} firstName : string
+  {field} lastName : string
+}
+
+"Customer" *--> "0..1" "Customer.name"  :  "name"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/anon-property-required.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/anon-property-required.puml
@@ -1,0 +1,24 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} name : Customer.name
+  {field} heightMetres : decimal {O}
+}
+
+class "Customer.name" {
+  {field} firstName : string
+  {field} lastName : string
+}
+
+"Customer" *--> "1" "Customer.name"  :  "name"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/any-of-anon-class-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/any-of-anon-class-level.puml
@@ -1,0 +1,29 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "employee" {
+}
+
+class "employee.1" {
+  {field} employeeType : string {O}
+  {field} level : integer
+}
+
+class "employee.2" {
+  {field} employeeType : string {O}
+  {field} income : decimal
+}
+
+"employee.1" --|> "employee"
+
+"employee.2" --|> "employee"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/any-of-anon-property-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/any-of-anon-property-level.puml
@@ -1,0 +1,34 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "employee" {
+  {field} role : employee.role {O}
+}
+
+class "employee.role" {
+  {field} employeeType : string {O}
+  {field} level : integer
+}
+
+class "employee.role.1" {
+  {field} employeeType : string {O}
+  {field} income : decimal
+}
+
+diamond anon1
+
+"employee" -->"0..1" "anon1" : "role"
+
+"employee.role" --|> "anon1"
+
+"employee.role.1" --|> "anon1"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/any-of-class-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/any-of-class-level.puml
@@ -1,0 +1,27 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "doctor" {
+  {field} income : decimal
+}
+
+class "employee" {
+}
+
+class "nurse" {
+  {field} level : integer
+}
+
+"doctor" --|> "employee"
+
+"nurse" --|> "employee"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/any-of-property-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/any-of-property-level.puml
@@ -1,0 +1,32 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "doctor" {
+  {field} income : decimal
+}
+
+class "employee" {
+  {field} role : doctor {O}
+}
+
+class "nurse" {
+  {field} level : integer
+}
+
+diamond anon1
+
+"employee" -->"0..1" "anon1" : "role"
+
+"doctor" --|> "anon1"
+
+"nurse" --|> "anon1"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/array-anon-class-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/array-anon-class-level.puml
@@ -1,0 +1,22 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customers" {
+}
+
+class "Customers.1" {
+  {field} firstName : string
+  {field} lastName : string
+}
+
+"Customers" --> "*" "Customers.1"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/array-anon-property-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/array-anon-property-level.puml
@@ -1,0 +1,23 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customers" {
+  {field} names : Customers.names[]
+}
+
+class "Customers.names" {
+  {field} firstName : string
+  {field} lastName : string
+}
+
+"Customers" --> "*" "Customers.names"  :  "names"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/array-class-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/array-class-level.puml
@@ -1,0 +1,22 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+}
+
+class "Customers" {
+}
+
+"Customers" --> "*" "Customer"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/array-property-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/array-property-level.puml
@@ -1,0 +1,23 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+}
+
+class "Customers" {
+  {field} group : Customer[]
+}
+
+"Customers" --> "*" "Customer"  :  "group"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/components-parameter-complex.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/components-parameter-complex.puml
@@ -1,0 +1,29 @@
+@startuml
+hide <<Method>> circle
+hide empty methods
+hide empty fields
+set namespaceSeparator none
+
+class "Customer" {
+  firstName : string {O}
+  lastName : string {O}
+}
+
+class "CustomerId" <<Parameter>> {
+  id : string {O}
+  prefix : string {O}
+}
+
+class "GET /customer/expired" <<Method>> {
+}
+
+class "GET /customer/expired 200 Response" <<Response>> {
+}
+
+"GET /customer/expired 200 Response" --> "*" "Customer"
+
+"GET /customer/expired" ..> "GET /customer/expired 200 Response": 200
+
+"GET /customer/expired" --> "1" "CustomerId" : "customerId"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/components-parameter.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/components-parameter.puml
@@ -1,0 +1,28 @@
+@startuml
+hide <<Method>> circle
+hide empty methods
+hide empty fields
+set namespaceSeparator none
+
+class "Customer" {
+  firstName : string {O}
+  lastName : string {O}
+}
+
+class "CustomerId" <<Parameter>> {
+  value : string
+}
+
+class "GET /customer/expired" <<Method>> {
+}
+
+class "GET /customer/expired 200 Response" <<Response>> {
+}
+
+"GET /customer/expired 200 Response" --> "*" "Customer"
+
+"GET /customer/expired" ..> "GET /customer/expired 200 Response": 200
+
+"GET /customer/expired" --> "1" "CustomerId" : "customerId"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/empty.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/empty.puml
@@ -1,0 +1,12 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/enum.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/enum.puml
@@ -1,0 +1,18 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+enum "EmployeeType" {
+  Doctor
+  Nurse
+  Administrator
+}
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/external-ref.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/external-ref.puml
@@ -1,0 +1,36 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "doctor" {
+  {field} income : decimal
+  {field} agreement : agreements.yml::agreement {O}
+}
+
+class "employee" {
+}
+
+class "nurse" {
+  {field} level : integer
+  {field} agreement : agreements.yml::agreement {O}
+}
+
+class "agreement" <<agreements.yml>> {
+}
+
+"employee" --> "1" "doctor"
+
+"employee" --> "1" "nurse"
+
+"nurse" --> "0..1" "agreement"  :  "agreement"
+
+"doctor" --> "0..1" "agreement"  :  "agreement"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/one-of-class-level-empty.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/one-of-class-level-empty.puml
@@ -1,0 +1,15 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "employee" {
+}
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/one-of-class-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/one-of-class-level.puml
@@ -1,0 +1,27 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "doctor" {
+  {field} income : decimal
+}
+
+class "employee" {
+}
+
+class "nurse" {
+  {field} level : integer
+}
+
+"doctor" --|> "employee"
+
+"nurse" --|> "employee"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/one-of-property-level-required.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/one-of-property-level-required.puml
@@ -1,0 +1,32 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "doctor" {
+  {field} income : decimal
+}
+
+class "employee" {
+  {field} role : doctor
+}
+
+class "nurse" {
+  {field} level : integer
+}
+
+diamond anon1
+
+"employee" -->"1" "anon1" : "role"
+
+"doctor" --|> "anon1"
+
+"nurse" --|> "anon1"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/one-of-property-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/one-of-property-level.puml
@@ -1,0 +1,32 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "doctor" {
+  {field} income : decimal
+}
+
+class "employee" {
+  {field} role : doctor {O}
+}
+
+class "nurse" {
+  {field} level : integer
+}
+
+diamond anon1
+
+"employee" -->"0..1" "anon1" : "role"
+
+"doctor" --|> "anon1"
+
+"nurse" --|> "anon1"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-anon-empty-object.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-anon-empty-object.puml
@@ -1,0 +1,37 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string {O}
+  {field} lastName : string {O}
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+class "GET /customer/expired 200" <<Response>>  {
+}
+
+class "GET /customer/expired.limit" <<Parameter>>  {
+}
+
+class "GET /customer/expired.offset" <<Parameter>>  {
+}
+
+"GET /customer/expired" --> "1" "GET /customer/expired.offset"  :  "offset"
+
+"GET /customer/expired" --> "0..1" "GET /customer/expired.limit"  :  "limit"
+
+"GET /customer/expired 200" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "GET /customer/expired 200"  :  "200"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-anon.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-anon.puml
@@ -1,0 +1,41 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string {O}
+  {field} lastName : string {O}
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+class "GET /customer/expired 200" <<Response>>  {
+}
+
+class "GET /customer/expired.limit" <<Parameter>>  {
+  {field} min : integer {O}
+  {field} max : integer {O}
+}
+
+class "GET /customer/expired.offset" <<Parameter>>  {
+  {field} min : integer {O}
+  {field} max : integer {O}
+}
+
+"GET /customer/expired" --> "1" "GET /customer/expired.offset"  :  "offset"
+
+"GET /customer/expired" --> "0..1" "GET /customer/expired.limit"  :  "limit"
+
+"GET /customer/expired 200" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "GET /customer/expired 200"  :  "200"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-ref-complex.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-ref-complex.puml
@@ -1,0 +1,34 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string {O}
+  {field} lastName : string {O}
+}
+
+class "CustomerId" <<Parameter>>  {
+  {field} id : string {O}
+  {field} prefix : string {O}
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+class "GET /customer/expired 200" <<Response>>  {
+}
+
+"GET /customer/expired" --> "1" "CustomerId"  :  "customerId"
+
+"GET /customer/expired 200" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "GET /customer/expired 200"  :  "200"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-ref-ref.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-ref-ref.puml
@@ -1,0 +1,38 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string {O}
+  {field} lastName : string {O}
+}
+
+class "CustomerId" <<Parameter>>  {
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+class "GET /customer/expired 200" <<Response>>  {
+}
+
+class "Id" <<Parameter>>  {
+  {field} value : string
+}
+
+"CustomerId" --> "1" "Id"
+
+"GET /customer/expired" --> "1" "CustomerId"  :  "id"
+
+"GET /customer/expired 200" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "GET /customer/expired 200"  :  "200"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-ref.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/parameter-ref.puml
@@ -1,0 +1,33 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string {O}
+  {field} lastName : string {O}
+}
+
+class "CustomerId" <<Parameter>>  {
+  {field} value : string
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+class "GET /customer/expired 200" <<Response>>  {
+}
+
+"GET /customer/expired" --> "1" "CustomerId"  :  "customerId"
+
+"GET /customer/expired 200" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "GET /customer/expired 200"  :  "200"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/path-returns-non-ref.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/path-returns-non-ref.puml
@@ -1,0 +1,35 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} heightMetres : decimal {O}
+  {field} dateOfBirth : date
+  {field} lastSessionTime : timestamp {O}
+  {field} numberOfChildren : integer {O}
+  {field} alive : boolean {O}
+  {field} nicknames : string[] {O}
+  {field} favouriteNumbers : integer[] {O}
+  {field} picture : byte[] {O}
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+class "GET /customer/expired 200" <<Response>>  {
+}
+
+"GET /customer/expired 200" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "GET /customer/expired 200"  :  "200"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/path-returns-ref-ref.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/path-returns-ref-ref.puml
@@ -1,0 +1,40 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} heightMetres : decimal {O}
+  {field} dateOfBirth : date
+  {field} lastSessionTime : timestamp {O}
+  {field} numberOfChildren : integer {O}
+  {field} alive : boolean {O}
+  {field} nicknames : string[] {O}
+  {field} favouriteNumbers : integer[] {O}
+  {field} picture : byte[] {O}
+}
+
+class "Customers" {
+}
+
+class "Customers.1" <<Response>>  {
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+"Customers" --> "*" "Customer"
+
+"Customers.1" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "Customers.1"  :  "200"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/path-returns-ref-ref2.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/path-returns-ref-ref2.puml
@@ -1,0 +1,40 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} heightMetres : decimal {O}
+  {field} dateOfBirth : date
+  {field} lastSessionTime : timestamp {O}
+  {field} numberOfChildren : integer {O}
+  {field} alive : boolean {O}
+  {field} nicknames : string[] {O}
+  {field} favouriteNumbers : integer[] {O}
+  {field} picture : byte[] {O}
+}
+
+class "Customers" {
+}
+
+class "Customers.1" <<Response>>  {
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+"Customers" --> "*" "Customer"
+
+"Customers.1" --> "1" "Customers"
+
+"GET /customer/expired" ..> "1" "Customers.1"  :  "200"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/path-returns-ref.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/path-returns-ref.puml
@@ -1,0 +1,35 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} heightMetres : decimal {O}
+  {field} dateOfBirth : date
+  {field} lastSessionTime : timestamp {O}
+  {field} numberOfChildren : integer {O}
+  {field} alive : boolean {O}
+  {field} nicknames : string[] {O}
+  {field} favouriteNumbers : integer[] {O}
+  {field} picture : byte[] {O}
+}
+
+class "Customers" <<Response>>  {
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+"Customers" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "Customers"  :  "200"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/petstore-expanded.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/petstore-expanded.puml
@@ -1,0 +1,75 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Error" {
+  {field} code : integer
+  {field} message : string
+}
+
+class "NewPet" {
+  {field} name : string
+  {field} tag : string {O}
+}
+
+class "Pet" {
+}
+
+class "PetId" {
+  {field} id : integer
+}
+
+class "addPet" <<Path>>  <<POST /pets>>  {
+}
+
+class "deletePet" <<Path>>  <<DELETE /pets/{id}>>  {
+  {field} id : integer
+}
+
+class "deletePet 204" <<Response>>  {
+}
+
+class "find pet by id" <<Path>>  <<GET /pets/{id}>>  {
+  {field} id : integer
+}
+
+class "findPets" <<Path>>  <<GET /pets>>  {
+  {field} tags : string[] {O}
+  {field} limit : integer {O}
+}
+
+class "findPets 200" <<Response>>  {
+}
+
+"Pet" --> "1" "NewPet"
+
+"Pet" --> "1" "PetId"
+
+"findPets 200" --> "*" "Pet"
+
+"findPets" ..> "1" "findPets 200"  :  "200"
+
+"findPets" ..> "1" "Error"  :  "default"
+
+"addPet" ..> "1" "Pet"  :  "200"
+
+"addPet" ..> "1" "Error"  :  "default"
+
+"addPet" --> "1" "NewPet"
+
+"find pet by id" ..> "1" "Pet"  :  "200"
+
+"find pet by id" ..> "1" "Error"  :  "default"
+
+"deletePet" ..> "1" "deletePet 204"  :  "204"
+
+"deletePet" ..> "1" "Error"  :  "default"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/petstore.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/petstore.puml
@@ -1,0 +1,54 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Error" {
+  {field} code : integer
+  {field} message : string
+}
+
+class "Pet" {
+  {field} id : integer
+  {field} name : string
+  {field} tag : string {O}
+}
+
+class "Pets" {
+}
+
+class "createPets" <<Path>>  <<POST /pets>>  {
+}
+
+class "createPets 201" <<Response>>  {
+}
+
+class "listPets" <<Path>>  <<GET /pets>>  {
+  {field} limit : integer {O}
+}
+
+class "showPetById" <<Path>>  <<GET /pets/{petId}>>  {
+  {field} petId : string
+}
+
+"Pets" --> "*" "Pet"
+
+"listPets" ..> "1" "Pets"  :  "200"
+
+"listPets" ..> "1" "Error"  :  "default"
+
+"createPets" ..> "1" "createPets 201"  :  "201"
+
+"createPets" ..> "1" "Error"  :  "default"
+
+"showPetById" ..> "1" "Pet"  :  "200"
+
+"showPetById" ..> "1" "Error"  :  "default"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/ref-class-level.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/ref-class-level.puml
@@ -1,0 +1,22 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Client" {
+}
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+}
+
+"Client" --> "1" "Customer"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/request-body-ref-ref.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/request-body-ref-ref.puml
@@ -1,0 +1,46 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} heightMetres : decimal {O}
+  {field} dateOfBirth : date
+  {field} lastSessionTime : timestamp {O}
+  {field} numberOfChildren : integer {O}
+  {field} alive : boolean {O}
+  {field} nicknames : string[] {O}
+  {field} favouriteNumbers : integer[] {O}
+  {field} picture : byte[] {O}
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+class "GET /customer/expired 200" <<Response>>  {
+}
+
+class "repositories" <<RequestBody>>  {
+}
+
+class "repositoriesAlt" <<RequestBody>>  {
+  {field} repository_ids : integer[] {O}
+}
+
+"repositories" --> "1" "repositoriesAlt"
+
+"GET /customer/expired 200" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "GET /customer/expired 200"  :  "200"
+
+"GET /customer/expired" --> "1" "repositories"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/request-body-ref.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/request-body-ref.puml
@@ -1,0 +1,41 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} heightMetres : decimal {O}
+  {field} dateOfBirth : date
+  {field} lastSessionTime : timestamp {O}
+  {field} numberOfChildren : integer {O}
+  {field} alive : boolean {O}
+  {field} nicknames : string[] {O}
+  {field} favouriteNumbers : integer[] {O}
+  {field} picture : byte[] {O}
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+class "GET /customer/expired 200" <<Response>>  {
+}
+
+class "repositories" <<RequestBody>>  {
+  {field} repository_ids : integer[] {O}
+}
+
+"GET /customer/expired 200" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "GET /customer/expired 200"  :  "200"
+
+"GET /customer/expired" --> "1" "repositories"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/request-body.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/request-body.puml
@@ -1,0 +1,41 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} heightMetres : decimal {O}
+  {field} dateOfBirth : date
+  {field} lastSessionTime : timestamp {O}
+  {field} numberOfChildren : integer {O}
+  {field} alive : boolean {O}
+  {field} nicknames : string[] {O}
+  {field} favouriteNumbers : integer[] {O}
+  {field} picture : byte[] {O}
+}
+
+class "GET /customer/expired" <<Path>>  {
+}
+
+class "GET /customer/expired 200" <<Response>>  {
+}
+
+class "GET /customer/expired Request" <<RequestBody>>  {
+  {field} repository_ids : integer[] {O}
+}
+
+"GET /customer/expired 200" --> "*" "Customer"
+
+"GET /customer/expired" ..> "1" "GET /customer/expired 200"  :  "200"
+
+"GET /customer/expired" --> "1" "GET /customer/expired Request"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/simple-has-refs.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/simple-has-refs.puml
@@ -1,0 +1,31 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} heightMetres : decimal {O}
+  {field} type : CustomerType
+  {field} friends : Customer[]
+  {field} favouritePartner : Customer {O}
+}
+
+class "CustomerType" {
+  {field} value : string
+}
+
+"Customer" --> "1" "CustomerType"  :  "type"
+
+"Customer" --> "*" "Customer"  :  "friends"
+
+"Customer" --> "0..1" "Customer"  :  "favouritePartner"
+
+@enduml

--- a/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/simple-types-and-arrays.puml
+++ b/openapi-to-plantuml/src/test/resources/outputs-incl-rel-fields/simple-types-and-arrays.puml
@@ -1,0 +1,30 @@
+@startuml
+hide <<Path>> circle
+hide <<Response>> circle
+hide <<Parameter>> circle
+hide empty methods
+hide empty fields
+skinparam class {
+BackgroundColor<<Path>> Wheat
+}
+set namespaceSeparator none
+
+class "My.Customer" {
+  {field} firstName : string
+  {field} lastName : string
+  {field} secret : string {O}
+  {field} email : string {O}
+  {field} id : string {O}
+  {field} history : byte[] {O}
+  {field} history2 : byte[] {O}
+  {field} heightMetres : decimal {O}
+  {field} dateOfBirth : date
+  {field} lastSessionTime : timestamp {O}
+  {field} numberOfChildren : integer {O}
+  {field} alive : boolean {O}
+  {field} nicknames : string[] {O}
+  {field} favouriteNumbers : integer[] {O}
+  {field} picture : byte[] {O}
+}
+
+@enduml


### PR DESCRIPTION
I want to be able to see relations not only as arrows between entities but also as fields inside the entities.

For this I added a configuration includeRelationFields which shows relation fields both as relation (default behaviour) and as field (added with this setting)

This code builds on from the openapi 3.1 support code